### PR TITLE
MES-1527 Add cloudwatch logging to microservice template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,54 @@ To run the unit tests, simply run:
 ```shell
 npm test
 ```
+
+## Logging
+
+To implement logging to a Custom AWS CloudWatch Log Group use the `createLogger` function, passing the name of the
+CloudWatch Log Group, to create an instance of the `Logger` class configured to log to CloudWatch.
+
+### Logging - Create `Logger` instance
+```typescript
+import Logger from '../../../common/application/logging/Logger';
+import { createLogger } from '../../../common/framework/logging/createLogger';
+
+const logger: Logger = await createLogger('ExampleLoggerName', process.env.CUSTOM_CWLG_NAME);
+```
+
+### Logging - Log an individual message
+```typescript
+async logger.log(message: string, logLevel: LogLevel, logData?: Bag): Promise<void>
+// where `LogLevel` can be 'debug' | 'info' | 'warn' | 'error'
+// where `Bag` is an object containing properties (i.e. `{ [propName: string]: any }`)
+```
+
+The `message`, `logLevel`, and optional additional `logData`, are combined together in to a single object and
+then JSON serialized to build the string that is sent to the logging system (i.e. CloudWatch in our case).
+
+Examples:
+```typescript
+// Individual log examples:
+await logger.log('Some debug log message', 'debug');
+await logger.log('Some information log message', 'info');
+await logger.log('Some warning log message', 'warn');
+await logger.log('Some error log message', 'error', error);
+```
+
+Note that optional additional data can be passed to provide more contextual information, regardless of log level:
+```typescript
+await logger.log('Some log message', 'info', { optionalAdditionalData: true, numOfAttempts: 3, ... });
+```
+
+### Logging - Log in batch
+```typescript
+async logger.logEvents(logEvents: LogEvent[]): Promise<void>
+```
+
+For example:
+```typescript
+import LogEvent from '../../../common/application/logging/LogEvent';
+
+// To log in batch:
+const logEvents: LogEvent[] = ...;
+await logger.logEvents(logEvents);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1742,6 +1742,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -6004,6 +6010,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postinstall-build": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.3.tgz",
+      "integrity": "sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg==",
+      "dev": true
+    },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
@@ -8329,6 +8341,17 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typemoq": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typemoq/-/typemoq-2.1.0.tgz",
+      "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "lodash": "^4.17.4",
+        "postinstall-build": "^5.0.1"
+      }
     },
     "typescript": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ts-loader": "^5.2.2",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.0",
+    "typemoq": "^2.1.0",
     "typescript": "^3.1.3",
     "webpack": "^4.22.0",
     "webpack-cli": "^3.1.2",

--- a/src/common/application/logging/LogEvent.ts
+++ b/src/common/application/logging/LogEvent.ts
@@ -1,0 +1,11 @@
+export default interface LogEvent {
+  /**
+   * The time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
+   */
+  timestamp: number;
+
+  /**
+   * The raw event message string.
+   */
+  message: string;
+}

--- a/src/common/application/logging/Logger.ts
+++ b/src/common/application/logging/Logger.ts
@@ -1,0 +1,48 @@
+import LogEvent from './LogEvent';
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type Bag = { [propName: string]: any };
+
+export type LogDelegate = (logEvents: LogEvent[]) => Promise<void>;
+
+export default class Logger {
+  private logDelegate: LogDelegate;
+
+  loggerName: string;
+
+  constructor(logDelegate: LogDelegate, loggerName: string) {
+    this.logDelegate = logDelegate;
+    this.loggerName = loggerName;
+  }
+
+  /**
+   * Sends the specified array of `LogEvents` to the logging system.
+   * @param logEvents The event messages to log.
+   * @returns `Promise` for completing the async action.
+   */
+  async logEvents(logEvents: LogEvent[]): Promise<void> {
+    try {
+      await this.logDelegate(logEvents);
+    } catch (e) {
+      console.error('Error occurred while attempting to log events to logging system:');
+      console.error(e);
+    }
+  }
+
+  /**
+   * Sends a `LogEvent`, with the specified message string, log level and
+   * optional additional log data, to the logging system.
+   * @param message The message string to log.
+   * @param logLevel The severity of the `LogEvent`.
+   * @param logData Optional, any additional data to include in the `LogEvent`.
+   * @returns `Promise` for completing the async action.
+   */
+  async log(message: string, logLevel: LogLevel, logData?: Bag): Promise<void> {
+    const eventMessage = Object.assign({ message, logLevel, loggerName: this.loggerName }, logData);
+
+    await this.logEvents([{
+      timestamp: new Date().getTime(),
+      message: JSON.stringify(eventMessage),
+    }]);
+  }
+}

--- a/src/common/application/logging/__tests__/Logger.spec.ts
+++ b/src/common/application/logging/__tests__/Logger.spec.ts
@@ -1,0 +1,78 @@
+import { Mock, It, Times } from 'typemoq';
+import LogEvent from '../LogEvent';
+import Logger, { LogDelegate } from '../Logger';
+
+describe('Logger', () => {
+  const moqLogDelegate = Mock.ofType<LogDelegate>();
+  let sut: Logger;
+
+  beforeEach(() => {
+    moqLogDelegate.reset();
+
+    sut = new Logger(moqLogDelegate.object, 'exampleTestLogger');
+  });
+
+  describe('logEvents', () => {
+    it('should call `logDelegate` as expected', async () => {
+      // ACT
+      await sut.logEvents(Array(3).fill(Mock.ofType<LogEvent>().object));
+
+      // ASSERT
+      moqLogDelegate.verify(
+        x => x(It.is<LogEvent[]>(evnts => evnts.length === 3)),
+        Times.once());
+    });
+
+    it('should swallow, and output to console error, any exceptions ', async () => {
+      moqLogDelegate.setup(x => x(It.isAny()))
+        .throws(new Error('example external logging system error'));
+
+      const moqConsoleError = Mock.ofInstance(console.error);
+      spyOn(console, 'error').and.callFake(moqConsoleError.object);
+
+      // ACT
+      await sut.logEvents([Mock.ofType<LogEvent>().object]);
+
+      // ASSERT
+      moqConsoleError.verify(
+        x => x('Error occurred while attempting to log events to logging system:'),
+        Times.once());
+
+      moqConsoleError.verify(
+          x => x(It.is<Error>(e => e.message === 'example external logging system error')),
+          Times.once());
+    });
+  });
+
+  describe('log', () => {
+    it('should call `logDelegate` as expected', async () => {
+      // ACT
+      await sut.log('test log message', 'info', { value: 1234 });
+
+      // ASSERT
+      moqLogDelegate.verify(
+        x => x(It.is<LogEvent[]>(evnts =>
+          evnts.length === 1 &&
+          evnts[0].timestamp > 0 &&
+          evnts[0].timestamp <= new Date().getTime() &&
+          /test log message/.test(evnts[0].message) &&
+          /info/.test(evnts[0].message) &&
+          /1234/.test(evnts[0].message))),
+        Times.once());
+    });
+
+    it('additional `logData` overrides other arguments', async () => {
+      // ACT
+      await sut.log('test log message', 'info', { logLevel: 'other' });
+
+      // ASSERT
+      moqLogDelegate.verify(
+        x => x(It.is<LogEvent[]>(evnts =>
+          evnts.length === 1 &&
+          /test log message/.test(evnts[0].message) &&
+          !/info/.test(evnts[0].message) &&
+          /other/.test(evnts[0].message))),
+        Times.once());
+    });
+  });
+});

--- a/src/common/framework/logging/__tests__/createLogger.spec.ts
+++ b/src/common/framework/logging/__tests__/createLogger.spec.ts
@@ -1,0 +1,215 @@
+import * as awsSdkMock from 'aws-sdk-mock';
+import { Mock, It, Times } from 'typemoq';
+import { CloudWatchLogs } from 'aws-sdk';
+import * as logger from '../createLogger';
+import { LogDelegate } from '../../../application/logging/Logger';
+
+describe('logging', () => {
+  const originalConsoleLog = console.log;
+  const moqConsoleLog = Mock.ofInstance(console.log);
+  const moqCreateLogStream = Mock.ofInstance(new CloudWatchLogs().createLogStream);
+  const moqPutLogEvents = Mock.ofInstance(new CloudWatchLogs().putLogEvents);
+
+  beforeEach(() => {
+    moqConsoleLog.reset();
+    moqCreateLogStream.reset();
+    moqPutLogEvents.reset();
+
+    moqCreateLogStream.setup(x => x(It.isAny(), It.isAny()))
+      .returns(() => <any><unknown>Promise.resolve(true));
+
+    moqPutLogEvents.setup(x => x(It.isAny(), It.isAny()))
+      .returns(() => <any><unknown>Promise.resolve(true));
+
+    moqConsoleLog
+      .setup(x => x(It.isAny(), It.isAny()))
+      .callback(
+        (message?: any, ...optionalParams: any[]) => originalConsoleLog(message, ...optionalParams));
+
+    awsSdkMock.mock('CloudWatchLogs', 'createLogStream', moqCreateLogStream.object);
+    awsSdkMock.mock('CloudWatchLogs', 'putLogEvents', moqPutLogEvents.object);
+
+    spyOn(console, 'log').and.callFake(moqConsoleLog.object);
+  });
+
+  afterEach(() => {
+    awsSdkMock.restore('CloudWatchLogs', 'createLogStream');
+    awsSdkMock.restore('CloudWatchLogs', 'putLogEvents');
+  });
+
+  describe('createLogger', () => {
+    const sut = logger.createLogger;
+
+    const initialisedConsoleLogging = 'Initialised console logging';
+    const initialisedCloudWatchLogging = 'Initialised Custom CloudWatch logging';
+
+    it('creates a console logger if no CloudWatch LogGroupName specified', async () => {
+      // ACT
+      const result = await sut('testLogger', undefined);
+
+      // ASSERT
+      expect(result).toBeDefined();
+      expect(result.loggerName).toEqual('testLogger');
+
+      moqConsoleLog.verify(x => x(It.is<string>(s => s.indexOf(initialisedConsoleLogging) !== -1)), Times.once());
+      moqConsoleLog.verify(x => x(It.is<string>(s => s.indexOf(initialisedCloudWatchLogging) !== -1)), Times.never());
+    });
+
+    it('creates a CloudWatch logger if CloudWatch LogGroupName is specified', async () => {
+      // ACT
+      const result = await sut('testLogger', 'cloudWatchLogGroupName');
+
+      // ASSERT
+      expect(result).toBeDefined();
+      expect(result.loggerName).toEqual('testLogger');
+
+      moqConsoleLog.verify(x => x(It.is<string>(s => s.indexOf(initialisedConsoleLogging) !== -1)), Times.never());
+      moqConsoleLog.verify(x => x(It.is<string>(s => s.indexOf(initialisedCloudWatchLogging) !== -1)), Times.once());
+    });
+  });
+
+  describe('createCloudWatchLogger', () => {
+    const sut = logger.createCloudWatchLogger;
+
+    it('creates a log delegate that logs to CloudWatch', async () => {
+      // ACT
+      const result: LogDelegate = await sut('testLoggerName', 'testLogGroupName');
+      await result([{ timestamp: 265473, message: 'test log message to cloudwatch' }]);
+
+      // ASSERT
+      moqPutLogEvents.verify(
+        x => x(
+          It.is<CloudWatchLogs.Types.PutLogEventsRequest>(r =>
+            r.logEvents[0].message === 'test log message to cloudwatch' &&
+            r.logGroupName === 'testLogGroupName' &&
+            r.logStreamName.indexOf('testLoggerName') > -1),
+          It.isAny()),
+        Times.once());
+    });
+
+    it('should call the `createLogStream` CloudWatchLogs method correctly', async () => {
+      // ACT
+      await sut('testLoggerName', 'testLogGroupName');
+
+      // ASSERT
+      moqCreateLogStream.verify(
+        x => x(
+          It.is<CloudWatchLogs.Types.CreateLogStreamRequest>(r =>
+            r.logGroupName === 'testLogGroupName' &&
+            /^testLoggerName-\d\d\d\d-\d\d-\d\d-[0-9a-f]{32}$/.test(r.logStreamName)),
+          It.isAny()),
+        Times.once());
+    });
+
+    it('should use `sequenceToken` from previous `putLogEvents` result', async () => {
+      moqPutLogEvents.reset();
+      moqPutLogEvents.setup(x => x(It.isAny(), It.isAny()))
+        .returns(() => <any><unknown>Promise.resolve({
+          nextSequenceToken: 'example-sequenceToken-123',
+        }));
+
+      // ACT
+      const result = await sut('testLoggerName', 'testLogGroupName');
+      await result([{ timestamp: 1, message: 'test log message to cloudwatch 1' }]);
+      await result([{ timestamp: 2, message: 'test log message to cloudwatch 2' }]);
+
+      // ASSERT
+      moqPutLogEvents.verify(
+        x => x(
+          It.is<CloudWatchLogs.Types.PutLogEventsRequest>(r =>
+            r.logEvents[0].message === 'test log message to cloudwatch 1' &&
+            r.sequenceToken === undefined),
+          It.isAny()),
+        Times.once());
+
+      moqPutLogEvents.verify(
+        x => x(
+          It.is<CloudWatchLogs.Types.PutLogEventsRequest>(r =>
+            r.logEvents[0].message === 'test log message to cloudwatch 2' &&
+            r.sequenceToken === 'example-sequenceToken-123'),
+          It.isAny()),
+        Times.once());
+    });
+
+    it('should swallow a `ResourceAlreadyExistsException` error', async () => {
+      awsSdkMock.remock('CloudWatchLogs', 'createLogStream', async () => {
+        throw {
+          errorType: 'ResourceAlreadyExistsException',
+        };
+      });
+
+      // ACT
+      const result = await sut('testLoggerName', 'testLogGroupName');
+
+      // ASSERT
+      expect(result).toBeDefined();
+    });
+
+    it('should throw on any other exceptions', async () => {
+      awsSdkMock.remock('CloudWatchLogs', 'createLogStream', async () => {
+        throw {
+          errorType: 'SomeOtherException',
+        };
+      });
+
+      let errorThrown: any | undefined = undefined;
+      let wasErrorThrown = false;
+
+      // ACT
+      try {
+        await sut('testLoggerName', 'testLogGroupName');
+      } catch (e) {
+        errorThrown = e;
+        wasErrorThrown = true;
+      }
+
+      // ASSERT
+      expect(wasErrorThrown).toEqual(true);
+      expect(errorThrown).toBeDefined();
+      expect(errorThrown.errorType).toEqual('SomeOtherException');
+    });
+  });
+
+  describe('createConsoleLogger', () => {
+    const sut = logger.createConsoleLogger;
+
+    it('creates a log delegate that logs to the console', async () => {
+      // ACT
+      const result: LogDelegate = sut('testLoggerName');
+      await result([{ timestamp: 347574, message: 'an example log message' }]);
+
+      // ASSERT
+      moqConsoleLog.verify(
+        x => x(
+          It.is<string>(s => /testLoggerName:/.test(s)),
+          It.is<any>(args => /^an example log message$/.test(args[0].message))),
+        Times.once());
+    });
+  });
+
+  describe('uniqueLogStreamName', () => {
+    const sut = logger.uniqueLogStreamName;
+
+    it('returns a string in the expected format', () => {
+      // ACT
+      const result = sut('LoggerName');
+
+      // ASSERT
+      expect(result).toMatch(/^LoggerName-\d\d\d\d-\d\d-\d\d-[0-9a-f]{32}$/);
+    });
+
+    it('generates unique names each time', () => {
+      const results = new Set();
+      const countToGenerate = 50000;
+
+      // ACT
+      for (let i = 0; i < countToGenerate; i = i + 1) {
+        const result = sut('LoggerName');
+        results.add(result);
+      }
+
+      // ASSERT
+      expect(results.size).toEqual(countToGenerate);
+    });
+  });
+});

--- a/src/common/framework/logging/createLogger.ts
+++ b/src/common/framework/logging/createLogger.ts
@@ -1,0 +1,67 @@
+import { CloudWatchLogs } from 'aws-sdk';
+import { randomBytes } from 'crypto';
+import LogEvent from '../../application/logging/LogEvent';
+import Logger, { LogDelegate } from '../../application/logging/Logger';
+
+export function uniqueLogStreamName(loggerName: string): string {
+  const date = new Date();
+  const year = date.getUTCFullYear();
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = date.getUTCDate().toString().padStart(2, '0');
+  const randomUuid = randomBytes(16).toString('hex');
+  return `${loggerName}-${year}-${month}-${day}-${randomUuid}`;
+}
+
+function ignoreResourceAlreadyExistsException(err: any) {
+  if ((err.errorType || err.code) !== 'ResourceAlreadyExistsException') {
+    throw err;
+  }
+}
+
+export async function createCloudWatchLogger(loggerName: string, logGroupName: string): Promise<LogDelegate> {
+  const cloudWatchLogs = new CloudWatchLogs();
+  const logStreamName = uniqueLogStreamName(loggerName);
+
+  await cloudWatchLogs.createLogStream({ logGroupName, logStreamName }).promise()
+    .catch(ignoreResourceAlreadyExistsException);
+
+  let sequenceToken: CloudWatchLogs.SequenceToken | undefined = undefined;
+
+  const cloudWatchLogger = async (logEvents: LogEvent[]) => {
+    const logResult = await cloudWatchLogs.putLogEvents({
+      logEvents,
+      logGroupName,
+      logStreamName,
+      sequenceToken,
+    }).promise();
+
+    sequenceToken = logResult.nextSequenceToken;
+  };
+
+  console.log(`Initialised Custom CloudWatch logging to: ${logGroupName}/${logStreamName}`);
+  return cloudWatchLogger;
+}
+
+export function createConsoleLogger(loggerName: string): LogDelegate {
+  console.log('Initialised console logging');
+  return async (logEvents: LogEvent[]) => console.log(`${loggerName}: %O`, logEvents);
+}
+
+/**
+ * Creates a `Logger` object, which can be used to send `LogMessage(s)` to the logging system.
+ * @param loggerName The name for the logger.
+ * @param cloudWatchLogGroupName The name for the AWS CloudWatch log group to send logs to.
+ * @returns `Promise` for completing the action, which returns the created `Logger`.
+ */
+export async function createLogger(loggerName: string, cloudWatchLogGroupName: string | undefined): Promise<Logger> {
+  // If the `cloudWatchLogGroupName` variable is set then log to that CloudWatch log group.
+  // This is also used to indicate we are running in the infrastructure, so the Amazon SDK will
+  // automatically pull access credentials from IAM Role.
+  // Otherwise, if the `cloudWatchLogGroupName` variable is NOT set, then log to the console.
+  const logDelegate = (cloudWatchLogGroupName && cloudWatchLogGroupName.length > 0)
+    ? await createCloudWatchLogger(loggerName, cloudWatchLogGroupName)
+    : createConsoleLogger(loggerName);
+
+  // Create and return the Logger.
+  return new Logger(logDelegate, loggerName);
+}


### PR DESCRIPTION
# MES-1527 Add cloudwatch logging to microservice template

Added classes and functions to enable developers to implement logging to a Custom AWS CloudWatch Log Group; and updated README.md to give a summary of how to use the classes.

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [ ] PR link added to JIRA